### PR TITLE
Add Intel Cyclone IV (Avalon-MM) support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,33 +6,63 @@ RTL_DIR    := rtl
 TB_DIR     := tb
 SIM_DIR    := sim
 
-RTL_SRC    := $(RTL_DIR)/i2c_master_core.v \
+# Shared core
+CORE_SRC   := $(RTL_DIR)/i2c_master_core.v
+
+# AXI variant (Zynq)
+AXI_SRC    := $(CORE_SRC) \
               $(RTL_DIR)/i2c_master_axi.v \
               $(RTL_DIR)/i2c_master_top.v
 
-TB_SRC     := $(TB_DIR)/i2c_slave_model.sv \
+AXI_TB     := $(TB_DIR)/i2c_slave_model.sv \
               $(TB_DIR)/axi_lite_master_bfm.sv \
               $(TB_DIR)/i2c_master_tb.sv
 
-SIM_OUT    := $(SIM_DIR)/i2c_master_tb.vvp
-WAVEFORM   := $(SIM_DIR)/i2c_master_tb.vcd
+# Avalon variant (Cyclone IV)
+AVL_SRC    := $(CORE_SRC) \
+              $(RTL_DIR)/i2c_master_avalon.v \
+              $(RTL_DIR)/i2c_master_top_c4.v
 
-.PHONY: all sim wave lint clean
+AVL_TB     := $(TB_DIR)/i2c_slave_model.sv \
+              $(TB_DIR)/avalon_mm_master_bfm.sv \
+              $(TB_DIR)/i2c_master_c4_tb.sv
+
+.PHONY: all sim sim-axi sim-c4 lint lint-axi lint-c4 wave clean
 
 all: sim
 
-sim:
+# ---- AXI (Zynq) ----
+
+sim-axi:
 	@mkdir -p $(SIM_DIR)
-	$(IVERILOG) -g2012 -Wall -o $(SIM_OUT) $(RTL_SRC) $(TB_SRC)
-	$(VVP) $(SIM_OUT) -vcd
-	@echo "--- Simulation complete ---"
+	$(IVERILOG) -g2012 -Wall -o $(SIM_DIR)/i2c_master_tb.vvp $(AXI_SRC) $(AXI_TB)
+	cd $(SIM_DIR) && $(VVP) i2c_master_tb.vvp -vcd
+	@echo "--- AXI simulation complete ---"
 
-wave: sim
-	@echo "Open $(WAVEFORM) in GTKWave or other waveform viewer."
+lint-axi:
+	$(VERILATOR) --lint-only -Wall -Wno-UNUSEDSIGNAL --top-module i2c_master_top $(AXI_SRC)
+	@echo "--- AXI lint passed ---"
 
-lint:
-	$(VERILATOR) --lint-only -Wall -Wno-UNUSEDSIGNAL --top-module i2c_master_top $(RTL_SRC)
-	@echo "--- Lint passed ---"
+# ---- Avalon (Cyclone IV) ----
+
+sim-c4:
+	@mkdir -p $(SIM_DIR)
+	$(IVERILOG) -g2012 -Wall -o $(SIM_DIR)/i2c_master_c4_tb.vvp $(AVL_SRC) $(AVL_TB)
+	cd $(SIM_DIR) && $(VVP) i2c_master_c4_tb.vvp -vcd
+	@echo "--- Cyclone IV simulation complete ---"
+
+lint-c4:
+	$(VERILATOR) --lint-only -Wall -Wno-UNUSEDSIGNAL --top-module i2c_master_top_c4 $(AVL_SRC)
+	@echo "--- Cyclone IV lint passed ---"
+
+# ---- Combined ----
+
+sim: sim-axi sim-c4
+
+lint: lint-axi lint-c4
+
+wave:
+	@echo "Open $(SIM_DIR)/*.vcd in GTKWave"
 
 clean:
 	rm -rf $(SIM_DIR)/*.vvp $(SIM_DIR)/*.vcd $(SIM_DIR)/*.fst obj_dir

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # I2C Master Controller
 
-Production-ready I2C мастер-контроллер с интерфейсом AXI4-Lite для интеграции в FPGA-часть Xilinx Zynq SoC.
+Production-ready I2C мастер-контроллер для FPGA с двумя вариантами шинного интерфейса:
+- **AXI4-Lite** — для Xilinx Zynq SoC (ветка `main`)
+- **Avalon-MM** — для Intel Cyclone IV / NIOS II (ветка `cyclone4`)
 
 ## Возможности
 
@@ -16,16 +18,17 @@ Production-ready I2C мастер-контроллер с интерфейсом
 
 ## Архитектура
 
+Ядро `i2c_master_core` — общее для обеих платформ. Шинная обёртка (AXI / Avalon) взаимозаменяема.
+
 ```mermaid
 graph TD
-    PS[Zynq PS / Linux] -->|AXI4-Lite| TOP[i2c_master_top]
-    TOP --> AXI[i2c_master_axi]
-    AXI --> CORE[i2c_master_core]
-    AXI --> SYNC[Синхронизаторы]
-    AXI --> PRE[Прескалер]
-    AXI --> SEQ[Секвенсер]
-    AXI --> IRQ[Прерывания]
-    TOP --> BUF[Tri-state буферы]
+    PS[CPU: ARM / NIOS II] -->|AXI4-Lite или Avalon-MM| WRAP[Обёртка: i2c_master_axi / avalon]
+    WRAP --> CORE[i2c_master_core]
+    WRAP --> SYNC[Синхронизаторы]
+    WRAP --> PRE[Прескалер]
+    WRAP --> SEQ[Секвенсер]
+    WRAP --> IRQ[Прерывания]
+    WRAP --> BUF[Tri-state буферы]
     BUF --> BUS[I2C Bus: SDA/SCL]
 ```
 
@@ -34,19 +37,24 @@ graph TD
 ```
 I2C_Master_Controller/
 ├── rtl/
-│   ├── i2c_master_core.v     # Низкоуровневое I2C ядро (FSM)
-│   ├── i2c_master_axi.v      # AXI4-Lite обёртка (регистры, прескалер, прерывания)
-│   └── i2c_master_top.v      # Top-level с tri-state буферами
+│   ├── i2c_master_core.v        # Низкоуровневое I2C ядро (FSM) — общее
+│   ├── i2c_master_axi.v         # AXI4-Lite обёртка (Zynq)
+│   ├── i2c_master_top.v         # Top-level AXI (Zynq)
+│   ├── i2c_master_avalon.v      # Avalon-MM обёртка (Cyclone IV)
+│   └── i2c_master_top_c4.v      # Top-level Avalon (Cyclone IV)
 ├── tb/
-│   ├── i2c_slave_model.sv    # Модель I2C slave (EEPROM 256 байт)
-│   ├── axi_lite_master_bfm.sv# AXI4-Lite master BFM
-│   └── i2c_master_tb.sv      # Основной тестбенч (10 сценариев)
-├── sim/                       # Артефакты симуляции
+│   ├── i2c_slave_model.sv       # Модель I2C slave (EEPROM 256 байт)
+│   ├── axi_lite_master_bfm.sv   # AXI4-Lite master BFM
+│   ├── i2c_master_tb.sv         # Тестбенч AXI (10 сценариев)
+│   ├── avalon_mm_master_bfm.sv  # Avalon-MM master BFM
+│   └── i2c_master_c4_tb.sv      # Тестбенч Avalon (10 сценариев)
+├── sim/                          # Артефакты симуляции
 ├── doc/
-│   ├── DESIGN.md              # Архитектура и FSM
-│   ├── REGISTERS.md           # Карта регистров
-│   ├── TESTPLAN.md            # План тестирования
-│   └── INTEGRATION.md         # Интеграция в Zynq
+│   ├── DESIGN.md                 # Архитектура и FSM
+│   ├── REGISTERS.md              # Карта регистров
+│   ├── TESTPLAN.md               # План тестирования
+│   ├── INTEGRATION.md            # Интеграция в Zynq
+│   └── INTEGRATION_CYCLONE4.md   # Интеграция в Cyclone IV
 ├── Makefile
 ├── .gitignore
 └── README.md
@@ -62,9 +70,10 @@ I2C_Master_Controller/
 ### Сборка и запуск тестов
 
 ```bash
-make sim        # Компиляция + симуляция
-make lint       # Lint-проверка RTL через Verilator
-make wave       # Генерация VCD для просмотра в GTKWave
+make sim        # Симуляция обоих вариантов (AXI + Avalon)
+make sim-axi    # Только AXI (Zynq) тестбенч
+make sim-c4     # Только Avalon (Cyclone IV) тестбенч
+make lint       # Lint-проверка обоих вариантов
 make clean      # Очистка артефактов
 ```
 
@@ -94,11 +103,15 @@ All tests PASSED
 
 Подробнее: [doc/REGISTERS.md](doc/REGISTERS.md)
 
-## Интеграция в Vivado / Zynq
+## Интеграция
 
+### Xilinx Zynq (AXI4-Lite)
 Контроллер подключается к PS через AXI Interconnect. Прерывание `irq_o` — к GIC через `IRQ_F2P`.
-
 Подробнее: [doc/INTEGRATION.md](doc/INTEGRATION.md)
+
+### Intel Cyclone IV (Avalon-MM)
+Контроллер подключается к NIOS II через Avalon Interconnect в Platform Designer (Qsys).
+Подробнее: [doc/INTEGRATION_CYCLONE4.md](doc/INTEGRATION_CYCLONE4.md)
 
 ## Документация
 
@@ -108,6 +121,7 @@ All tests PASSED
 | [REGISTERS.md](doc/REGISTERS.md) | Полная карта регистров с битовыми полями |
 | [TESTPLAN.md](doc/TESTPLAN.md) | Тестовые сценарии и план верификации |
 | [INTEGRATION.md](doc/INTEGRATION.md) | Интеграция в Zynq, Device Tree, Linux-драйвер |
+| [INTEGRATION_CYCLONE4.md](doc/INTEGRATION_CYCLONE4.md) | Интеграция в Cyclone IV, NIOS II, Platform Designer |
 
 ## Лицензия
 

--- a/doc/INTEGRATION_CYCLONE4.md
+++ b/doc/INTEGRATION_CYCLONE4.md
@@ -1,0 +1,209 @@
+# Интеграция I2C Master Controller в Intel Cyclone IV
+
+## Обзор
+
+Данный документ описывает интеграцию IP-ядра `i2c_master_top_c4` (Avalon-MM вариант) в FPGA Intel Cyclone IV для работы с NIOS II или прямого управления.
+
+## Архитектура интеграции
+
+```mermaid
+graph TB
+    subgraph NIOS [NIOS II Processor]
+        SW[Firmware / HAL]
+    end
+    subgraph FPGA [Cyclone IV FPGA]
+        AVLIC[Avalon Interconnect]
+        I2C[i2c_master_top_c4]
+    end
+    subgraph BUS [I2C Bus]
+        DEV[EEPROM / Sensor / etc.]
+    end
+
+    SW -->|Avalon-MM| AVLIC
+    AVLIC --> I2C
+    I2C -->|irq_o| NIOS
+    I2C -->|SDA/SCL| DEV
+```
+
+## Шаги интеграции в Quartus / Platform Designer
+
+### 1. Добавление RTL файлов
+
+Добавить в проект Quartus:
+- `rtl/i2c_master_core.v`
+- `rtl/i2c_master_avalon.v`
+- `rtl/i2c_master_top_c4.v` (опционально, для tri-state на уровне top)
+
+### 2. Создание компонента в Platform Designer (Qsys)
+
+Для интеграции с NIOS II создайте Avalon-MM Slave компонент:
+
+**Интерфейсы:**
+| Имя | Тип | Описание |
+|-----|-----|----------|
+| clock | Clock Input | Тактовый сигнал |
+| reset | Reset Input | Активный низкий сброс |
+| avalon_slave | Avalon-MM Slave | Регистры управления |
+| irq | Interrupt Sender | Прерывание |
+| conduit_sda | Conduit | SDA pad (export) |
+| conduit_scl | Conduit | SCL pad (export) |
+
+**Параметры Avalon-MM Slave:**
+| Параметр | Значение |
+|----------|----------|
+| Address Width | 3 (word-addressed) |
+| Data Width | 32 |
+| Read Latency | 0 |
+| Wait States | 0 |
+
+**При использовании `i2c_master_avalon` напрямую:**
+- Экспортировать `scl_pad_i`, `scl_pad_o`, `scl_padoen_o` как conduit
+- Аналогично для SDA
+- В top-level подключить к IOBUF/ALT_IOBUF
+
+**При использовании `i2c_master_top_c4`:**
+- Экспортировать `sda_io`, `scl_io` как bidirectional conduit
+
+### 3. Назначение пинов
+
+В файле `.qsf` или Pin Planner:
+
+```tcl
+set_location_assignment PIN_XX -to sda_io
+set_location_assignment PIN_YY -to scl_io
+
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to sda_io
+set_instance_assignment -name IO_STANDARD "3.3-V LVCMOS" -to scl_io
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to sda_io
+set_instance_assignment -name WEAK_PULL_UP_RESISTOR ON -to scl_io
+```
+
+**Замечание:** Cyclone IV поддерживает внутренние pull-up (~25 кОм), но для надёжной работы I2C шины рекомендуются внешние pull-up 2.2–4.7 кОм.
+
+### 4. Прескалер для Cyclone IV
+
+Типичные тактовые частоты Cyclone IV:
+
+| Clk | PRESCALE | SCL |
+|-----|----------|-----|
+| 50 МГц | 124 (0x7C) | 100 кГц |
+| 50 МГц | 31 (0x1F) | 400 кГц |
+| 100 МГц | 249 (0xF9) | 100 кГц |
+
+Формула: `SCL = clk / (4 × (PRESCALE + 1))`
+
+Параметр `DEFAULT_PRESCALE` в `i2c_master_top_c4` установлен в 124 (100 кГц при 50 МГц).
+
+## Программирование из NIOS II (HAL)
+
+### Определение регистров
+
+```c
+#include "system.h"
+#include "io.h"
+
+#define I2C_BASE  I2C_MASTER_0_BASE  // Из system.h
+
+#define I2C_CTRL      (I2C_BASE + 0x00)
+#define I2C_STATUS    (I2C_BASE + 0x04)
+#define I2C_CMD       (I2C_BASE + 0x08)
+#define I2C_TX_DATA   (I2C_BASE + 0x0C)
+#define I2C_RX_DATA   (I2C_BASE + 0x10)
+#define I2C_PRESCALE  (I2C_BASE + 0x14)
+#define I2C_ISR       (I2C_BASE + 0x18)
+
+#define CMD_STA   0x01
+#define CMD_STO   0x02
+#define CMD_RD    0x04
+#define CMD_WR    0x08
+#define CMD_NACK  0x10
+
+#define STATUS_TIP    0x01
+#define STATUS_RXACK  0x02
+#define STATUS_BUSY   0x04
+#define STATUS_AL     0x08
+```
+
+### Инициализация
+
+```c
+void i2c_init(int prescale) {
+    IOWR_32DIRECT(I2C_CTRL, 0, 0x00);       // Выключить
+    IOWR_32DIRECT(I2C_PRESCALE, 0, prescale);
+    IOWR_32DIRECT(I2C_CTRL, 0, 0x03);       // EN=1, IEN=1
+}
+```
+
+### Запись байта
+
+```c
+int i2c_write_byte(uint8_t slave_addr, uint8_t reg, uint8_t data) {
+    // Адрес slave (write)
+    IOWR_32DIRECT(I2C_TX_DATA, 0, (slave_addr << 1) | 0);
+    IOWR_32DIRECT(I2C_CMD, 0, CMD_STA | CMD_WR);
+    while (IORD_32DIRECT(I2C_STATUS, 0) & STATUS_TIP);
+    if (IORD_32DIRECT(I2C_STATUS, 0) & STATUS_RXACK) return -1; // NACK
+
+    // Адрес регистра
+    IOWR_32DIRECT(I2C_TX_DATA, 0, reg);
+    IOWR_32DIRECT(I2C_CMD, 0, CMD_WR);
+    while (IORD_32DIRECT(I2C_STATUS, 0) & STATUS_TIP);
+
+    // Данные + STOP
+    IOWR_32DIRECT(I2C_TX_DATA, 0, data);
+    IOWR_32DIRECT(I2C_CMD, 0, CMD_WR | CMD_STO);
+    while (IORD_32DIRECT(I2C_STATUS, 0) & STATUS_TIP);
+
+    return 0;
+}
+```
+
+### Чтение байта
+
+```c
+int i2c_read_byte(uint8_t slave_addr, uint8_t reg, uint8_t *data) {
+    // Адрес slave (write) + регистр
+    IOWR_32DIRECT(I2C_TX_DATA, 0, (slave_addr << 1) | 0);
+    IOWR_32DIRECT(I2C_CMD, 0, CMD_STA | CMD_WR);
+    while (IORD_32DIRECT(I2C_STATUS, 0) & STATUS_TIP);
+    if (IORD_32DIRECT(I2C_STATUS, 0) & STATUS_RXACK) return -1;
+
+    IOWR_32DIRECT(I2C_TX_DATA, 0, reg);
+    IOWR_32DIRECT(I2C_CMD, 0, CMD_WR);
+    while (IORD_32DIRECT(I2C_STATUS, 0) & STATUS_TIP);
+
+    // Repeated START + адрес slave (read)
+    IOWR_32DIRECT(I2C_TX_DATA, 0, (slave_addr << 1) | 1);
+    IOWR_32DIRECT(I2C_CMD, 0, CMD_STA | CMD_WR);
+    while (IORD_32DIRECT(I2C_STATUS, 0) & STATUS_TIP);
+    if (IORD_32DIRECT(I2C_STATUS, 0) & STATUS_RXACK) return -1;
+
+    // Чтение + NACK + STOP
+    IOWR_32DIRECT(I2C_CMD, 0, CMD_RD | CMD_NACK | CMD_STO);
+    while (IORD_32DIRECT(I2C_STATUS, 0) & STATUS_TIP);
+
+    *data = IORD_32DIRECT(I2C_RX_DATA, 0) & 0xFF;
+    return 0;
+}
+```
+
+## Отличия от AXI (Zynq) варианта
+
+| Аспект | Zynq (main) | Cyclone IV (cyclone4) |
+|--------|-------------|----------------------|
+| Шинный интерфейс | AXI4-Lite | Avalon-MM |
+| Top-level | `i2c_master_top.v` | `i2c_master_top_c4.v` |
+| Обёртка | `i2c_master_axi.v` | `i2c_master_avalon.v` |
+| Адресация | Байтовая (5-bit) | Пословная (3-bit) |
+| I2C ядро | `i2c_master_core.v` — **общее** | `i2c_master_core.v` — **общее** |
+| Карта регистров | Идентичная | Идентичная |
+| Прескалер по умолч. | 249 (100M→100k) | 124 (50M→100k) |
+| Процессор | ARM Cortex-A9 | NIOS II |
+
+## Рекомендации
+
+1. **Pull-up:** обязательно внешние 2.2–4.7 кОм на SDA/SCL
+2. **Voltage levels:** Cyclone IV поддерживает 3.3V, 2.5V, 1.8V LVCMOS — выбрать совместимый с I2C slave
+3. **Clock:** использовать стабильный тактовый сигнал от PLL
+4. **NIOS II:** для interrupt-driven подхода настроить IRQ в HAL BSP settings
+5. **Тестирование:** начать с polling-режима, затем перейти на прерывания

--- a/rtl/i2c_master_avalon.v
+++ b/rtl/i2c_master_avalon.v
@@ -1,0 +1,424 @@
+`timescale 1ns / 1ps
+// ---------------------------------------------------------------------------
+// I2C Master — Avalon-MM slave wrapper (Intel/Altera)
+//
+// Drop-in replacement for i2c_master_axi, using Avalon-MM bus protocol
+// for NIOS II / Platform Designer integration.
+//
+// Register map identical to AXI version (32-bit data, byte-address step = 4):
+//   0x00  CTRL      R/W   [1:0] = {IEN, EN}
+//   0x04  STATUS    R     [3:0] = {AL, BUSY, RXACK, TIP}
+//   0x08  CMD       W     [4:0] = {NACK, WR, RD, STO, STA}
+//   0x0C  TX_DATA   R/W   [7:0]
+//   0x10  RX_DATA   R     [7:0]
+//   0x14  PRESCALE  R/W   [15:0]   SCL = clk / (4*(PRESCALE+1))
+//   0x18  ISR       R/W1C [1:0] = {AL_IRQ, DONE_IRQ}
+// ---------------------------------------------------------------------------
+module i2c_master_avalon #(
+    parameter DEFAULT_PRESCALE = 16'd249   // 50 MHz → 50 kHz default
+)(
+    // Avalon-MM slave interface
+    input  wire        clk,
+    input  wire        reset_n,
+
+    input  wire [2:0]  avs_address,        // Word address (0-6)
+    input  wire        avs_read,
+    output reg  [31:0] avs_readdata,
+    input  wire        avs_write,
+    input  wire [31:0] avs_writedata,
+    input  wire [3:0]  avs_byteenable,
+    output wire        avs_waitrequest,
+
+    // Interrupt (directly to NIOS II IRQ controller)
+    output wire        irq_o,
+
+    // I2C pads (active-low open-drain)
+    input  wire        scl_pad_i,
+    output wire        scl_pad_o,
+    output wire        scl_padoen_o,       // 1=tristate, 0=drive low
+    input  wire        sda_pad_i,
+    output wire        sda_pad_o,
+    output wire        sda_padoen_o        // 1=tristate, 0=drive low
+);
+
+    // Avalon-MM: no wait states for register access
+    assign avs_waitrequest = 1'b0;
+
+    // Constant low output (open-drain drives 0 when enabled)
+    assign scl_pad_o = 1'b0;
+    assign sda_pad_o = 1'b0;
+
+    // ---------------------------------------------------------------
+    // 2-stage synchronisers for SDA and SCL inputs
+    // ---------------------------------------------------------------
+    reg [1:0] scl_sync_r;
+    reg [1:0] sda_sync_r;
+
+    always @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
+            scl_sync_r <= 2'b11;
+            sda_sync_r <= 2'b11;
+        end else begin
+            scl_sync_r <= {scl_sync_r[0], scl_pad_i};
+            sda_sync_r <= {sda_sync_r[0], sda_pad_i};
+        end
+    end
+
+    wire scl_sync = scl_sync_r[1];
+    wire sda_sync = sda_sync_r[1];
+
+    // ---------------------------------------------------------------
+    // Register addresses (word-aligned, address is word index)
+    // ---------------------------------------------------------------
+    localparam [2:0]
+        ADDR_CTRL     = 3'd0,   // 0x00
+        ADDR_STATUS   = 3'd1,   // 0x04
+        ADDR_CMD      = 3'd2,   // 0x08
+        ADDR_TX_DATA  = 3'd3,   // 0x0C
+        ADDR_RX_DATA  = 3'd4,   // 0x10
+        ADDR_PRESCALE = 3'd5,   // 0x14
+        ADDR_ISR      = 3'd6;   // 0x18
+
+    // ---------------------------------------------------------------
+    // Software-writable registers
+    // ---------------------------------------------------------------
+    reg        ctrl_en_r;
+    reg        ctrl_ien_r;
+    reg [15:0] prescale_r;
+    reg [7:0]  tx_data_r;
+
+    reg        cmd_sta_r, cmd_sto_r, cmd_rd_r, cmd_wr_r, cmd_nack_r;
+    reg        cmd_write_strobe;
+
+    reg        isr_done_r;
+    reg        isr_al_r;
+
+    // ---------------------------------------------------------------
+    // Core outputs
+    // ---------------------------------------------------------------
+    wire [7:0] core_dout;
+    wire       core_rx_ack;
+    wire       core_ready;
+    wire       core_arb_lost;
+    wire       core_busy;
+    wire       core_scl_oen;
+    wire       core_sda_oen;
+
+    assign scl_padoen_o = ctrl_en_r ? core_scl_oen : 1'b1;
+    assign sda_padoen_o = ctrl_en_r ? core_sda_oen : 1'b1;
+
+    // ---------------------------------------------------------------
+    // Prescaler
+    // ---------------------------------------------------------------
+    reg [15:0] prescale_cnt_r;
+    reg        core_ena_r;
+
+    always @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
+            prescale_cnt_r <= 16'd0;
+            core_ena_r     <= 1'b0;
+        end else if (!ctrl_en_r) begin
+            prescale_cnt_r <= prescale_r;
+            core_ena_r     <= 1'b0;
+        end else if (prescale_cnt_r == 16'd0) begin
+            prescale_cnt_r <= prescale_r;
+            core_ena_r     <= 1'b1;
+        end else begin
+            prescale_cnt_r <= prescale_cnt_r - 16'd1;
+            core_ena_r     <= 1'b0;
+        end
+    end
+
+    // ---------------------------------------------------------------
+    // Command sequencer (identical to AXI version)
+    // ---------------------------------------------------------------
+    localparam [2:0] CMD_C_NOP     = 3'd0,
+                     CMD_C_START   = 3'd1,
+                     CMD_C_WRITE   = 3'd2,
+                     CMD_C_READ    = 3'd3,
+                     CMD_C_STOP    = 3'd4,
+                     CMD_C_RESTART = 3'd5;
+
+    localparam [2:0] SEQ_IDLE  = 3'd0,
+                     SEQ_START = 3'd1,
+                     SEQ_WRITE = 3'd2,
+                     SEQ_READ  = 3'd3,
+                     SEQ_STOP  = 3'd4;
+
+    reg [2:0]  seq_state_r;
+    reg        seq_sto_r, seq_wr_r, seq_rd_r, seq_nack_r;
+    reg        core_cmd_valid_r;
+    reg [2:0]  core_cmd_r;
+    reg [7:0]  core_din_r;
+    reg        tip_r;
+    reg        sub_cmd_sent_r;
+
+    wire       core_arb_lost_clear = cmd_write_strobe;
+
+    always @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
+            seq_state_r      <= SEQ_IDLE;
+            core_cmd_valid_r <= 1'b0;
+            core_cmd_r       <= CMD_C_NOP;
+            core_din_r       <= 8'd0;
+            tip_r            <= 1'b0;
+            sub_cmd_sent_r   <= 1'b0;
+            seq_sto_r        <= 1'b0;
+            seq_wr_r         <= 1'b0;
+            seq_rd_r         <= 1'b0;
+            seq_nack_r       <= 1'b0;
+        end else if (!ctrl_en_r) begin
+            seq_state_r      <= SEQ_IDLE;
+            core_cmd_valid_r <= 1'b0;
+            tip_r            <= 1'b0;
+            sub_cmd_sent_r   <= 1'b0;
+        end else if (core_arb_lost) begin
+            seq_state_r      <= SEQ_IDLE;
+            core_cmd_valid_r <= 1'b0;
+            tip_r            <= 1'b0;
+            sub_cmd_sent_r   <= 1'b0;
+        end else begin
+            case (seq_state_r)
+
+            SEQ_IDLE: begin
+                core_cmd_valid_r <= 1'b0;
+                sub_cmd_sent_r   <= 1'b0;
+                if (cmd_write_strobe) begin
+                    tip_r      <= 1'b1;
+                    seq_sto_r  <= cmd_sto_r;
+                    seq_wr_r   <= cmd_wr_r;
+                    seq_rd_r   <= cmd_rd_r;
+                    seq_nack_r <= cmd_nack_r;
+
+                    if (cmd_sta_r) begin
+                        core_cmd_r       <= core_busy ? CMD_C_RESTART : CMD_C_START;
+                        core_cmd_valid_r <= 1'b1;
+                        seq_state_r      <= SEQ_START;
+                    end else if (cmd_wr_r) begin
+                        core_cmd_r       <= CMD_C_WRITE;
+                        core_din_r       <= tx_data_r;
+                        core_cmd_valid_r <= 1'b1;
+                        seq_state_r      <= SEQ_WRITE;
+                    end else if (cmd_rd_r) begin
+                        core_cmd_r       <= CMD_C_READ;
+                        core_din_r       <= {7'd0, cmd_nack_r};
+                        core_cmd_valid_r <= 1'b1;
+                        seq_state_r      <= SEQ_READ;
+                    end else if (cmd_sto_r) begin
+                        core_cmd_r       <= CMD_C_STOP;
+                        core_cmd_valid_r <= 1'b1;
+                        seq_state_r      <= SEQ_STOP;
+                    end else begin
+                        tip_r <= 1'b0;
+                    end
+                end
+            end
+
+            SEQ_START: begin
+                if (!sub_cmd_sent_r) begin
+                    if (!core_ready) begin
+                        core_cmd_valid_r <= 1'b0;
+                        sub_cmd_sent_r   <= 1'b1;
+                    end
+                end else if (core_ready) begin
+                    sub_cmd_sent_r <= 1'b0;
+                    if (seq_wr_r) begin
+                        core_cmd_r       <= CMD_C_WRITE;
+                        core_din_r       <= tx_data_r;
+                        core_cmd_valid_r <= 1'b1;
+                        seq_state_r      <= SEQ_WRITE;
+                    end else if (seq_rd_r) begin
+                        core_cmd_r       <= CMD_C_READ;
+                        core_din_r       <= {7'd0, seq_nack_r};
+                        core_cmd_valid_r <= 1'b1;
+                        seq_state_r      <= SEQ_READ;
+                    end else begin
+                        tip_r       <= 1'b0;
+                        seq_state_r <= SEQ_IDLE;
+                    end
+                end
+            end
+
+            SEQ_WRITE: begin
+                if (!sub_cmd_sent_r) begin
+                    if (!core_ready) begin
+                        core_cmd_valid_r <= 1'b0;
+                        sub_cmd_sent_r   <= 1'b1;
+                    end
+                end else if (core_ready) begin
+                    sub_cmd_sent_r <= 1'b0;
+                    if (seq_sto_r) begin
+                        core_cmd_r       <= CMD_C_STOP;
+                        core_cmd_valid_r <= 1'b1;
+                        seq_state_r      <= SEQ_STOP;
+                    end else begin
+                        tip_r       <= 1'b0;
+                        seq_state_r <= SEQ_IDLE;
+                    end
+                end
+            end
+
+            SEQ_READ: begin
+                if (!sub_cmd_sent_r) begin
+                    if (!core_ready) begin
+                        core_cmd_valid_r <= 1'b0;
+                        sub_cmd_sent_r   <= 1'b1;
+                    end
+                end else if (core_ready) begin
+                    sub_cmd_sent_r <= 1'b0;
+                    if (seq_sto_r) begin
+                        core_cmd_r       <= CMD_C_STOP;
+                        core_cmd_valid_r <= 1'b1;
+                        seq_state_r      <= SEQ_STOP;
+                    end else begin
+                        tip_r       <= 1'b0;
+                        seq_state_r <= SEQ_IDLE;
+                    end
+                end
+            end
+
+            SEQ_STOP: begin
+                if (!sub_cmd_sent_r) begin
+                    if (!core_ready) begin
+                        core_cmd_valid_r <= 1'b0;
+                        sub_cmd_sent_r   <= 1'b1;
+                    end
+                end else if (core_ready) begin
+                    sub_cmd_sent_r <= 1'b0;
+                    tip_r          <= 1'b0;
+                    seq_state_r    <= SEQ_IDLE;
+                end
+            end
+
+            default: seq_state_r <= SEQ_IDLE;
+            endcase
+        end
+    end
+
+    // ---------------------------------------------------------------
+    // Interrupt logic
+    // ---------------------------------------------------------------
+    reg tip_d_r;
+    reg core_al_d_r;
+
+    always @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
+            tip_d_r     <= 1'b0;
+            core_al_d_r <= 1'b0;
+        end else begin
+            tip_d_r     <= tip_r;
+            core_al_d_r <= core_arb_lost;
+        end
+    end
+
+    wire tip_fall = tip_d_r & ~tip_r;
+    wire al_rise  = core_arb_lost & ~core_al_d_r;
+
+    assign irq_o = ctrl_ien_r & (isr_done_r | isr_al_r);
+
+    // ---------------------------------------------------------------
+    // Avalon-MM write logic
+    // ---------------------------------------------------------------
+    always @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
+            ctrl_en_r        <= 1'b0;
+            ctrl_ien_r       <= 1'b0;
+            prescale_r       <= DEFAULT_PRESCALE;
+            tx_data_r        <= 8'd0;
+            cmd_sta_r        <= 1'b0;
+            cmd_sto_r        <= 1'b0;
+            cmd_rd_r         <= 1'b0;
+            cmd_wr_r         <= 1'b0;
+            cmd_nack_r       <= 1'b0;
+            cmd_write_strobe <= 1'b0;
+            isr_done_r       <= 1'b0;
+            isr_al_r         <= 1'b0;
+        end else begin
+            cmd_write_strobe <= 1'b0;
+
+            // ISR set events
+            if (tip_fall) isr_done_r <= 1'b1;
+            if (al_rise)  isr_al_r   <= 1'b1;
+
+            if (avs_write) begin
+                case (avs_address)
+                    ADDR_CTRL: begin
+                        if (avs_byteenable[0]) begin
+                            ctrl_en_r  <= avs_writedata[0];
+                            ctrl_ien_r <= avs_writedata[1];
+                        end
+                    end
+                    ADDR_CMD: begin
+                        if (avs_byteenable[0]) begin
+                            cmd_sta_r        <= avs_writedata[0];
+                            cmd_sto_r        <= avs_writedata[1];
+                            cmd_rd_r         <= avs_writedata[2];
+                            cmd_wr_r         <= avs_writedata[3];
+                            cmd_nack_r       <= avs_writedata[4];
+                            cmd_write_strobe <= 1'b1;
+                        end
+                    end
+                    ADDR_TX_DATA: begin
+                        if (avs_byteenable[0]) tx_data_r <= avs_writedata[7:0];
+                    end
+                    ADDR_PRESCALE: begin
+                        if (avs_byteenable[0]) prescale_r[7:0]  <= avs_writedata[7:0];
+                        if (avs_byteenable[1]) prescale_r[15:8] <= avs_writedata[15:8];
+                    end
+                    ADDR_ISR: begin
+                        if (avs_byteenable[0]) begin
+                            if (avs_writedata[0]) isr_done_r <= 1'b0;
+                            if (avs_writedata[1]) isr_al_r   <= 1'b0;
+                        end
+                    end
+                    default: ;
+                endcase
+            end
+        end
+    end
+
+    // ---------------------------------------------------------------
+    // Avalon-MM read logic (combinational, 0 wait states)
+    // ---------------------------------------------------------------
+    always @(*) begin
+        avs_readdata = 32'd0;
+        if (avs_read) begin
+            case (avs_address)
+                ADDR_CTRL:     avs_readdata[1:0]  = {ctrl_ien_r, ctrl_en_r};
+                ADDR_STATUS:   avs_readdata[3:0]  = {core_arb_lost, core_busy, core_rx_ack, tip_r};
+                ADDR_TX_DATA:  avs_readdata[7:0]  = tx_data_r;
+                ADDR_RX_DATA:  avs_readdata[7:0]  = core_dout;
+                ADDR_PRESCALE: avs_readdata[15:0] = prescale_r;
+                ADDR_ISR:      avs_readdata[1:0]  = {isr_al_r, isr_done_r};
+                default:       avs_readdata        = 32'd0;
+            endcase
+        end
+    end
+
+    // ---------------------------------------------------------------
+    // I2C master core instantiation
+    // ---------------------------------------------------------------
+    i2c_master_core u_core (
+        .clk_i            (clk),
+        .rstn_i           (reset_n),
+        .ena_i            (core_ena_r),
+
+        .cmd_valid_i      (core_cmd_valid_r),
+        .cmd_i            (core_cmd_r),
+        .din_i            (core_din_r),
+
+        .dout_o           (core_dout),
+        .rx_ack_o         (core_rx_ack),
+        .ready_o          (core_ready),
+
+        .arb_lost_o       (core_arb_lost),
+        .arb_lost_clear_i (core_arb_lost_clear),
+        .busy_o           (core_busy),
+
+        .scl_i            (scl_sync),
+        .scl_oen_o        (core_scl_oen),
+        .sda_i            (sda_sync),
+        .sda_oen_o        (core_sda_oen)
+    );
+
+endmodule

--- a/rtl/i2c_master_top_c4.v
+++ b/rtl/i2c_master_top_c4.v
@@ -1,0 +1,70 @@
+`timescale 1ns / 1ps
+// ---------------------------------------------------------------------------
+// I2C Master Top — Cyclone IV variant
+//
+// Wraps i2c_master_avalon with tri-state (inout) pads for SDA/SCL.
+// For Platform Designer (Qsys) integration, instantiate i2c_master_avalon
+// directly and connect _pad_o / _padoen_o to ALT_IOBUF or bidir pins.
+// ---------------------------------------------------------------------------
+module i2c_master_top_c4 #(
+    parameter DEFAULT_PRESCALE = 16'd124   // 50 MHz → 100 kHz
+)(
+    // Avalon-MM slave
+    input  wire        clk,
+    input  wire        reset_n,
+
+    input  wire [2:0]  avs_address,
+    input  wire        avs_read,
+    output wire [31:0] avs_readdata,
+    input  wire        avs_write,
+    input  wire [31:0] avs_writedata,
+    input  wire [3:0]  avs_byteenable,
+    output wire        avs_waitrequest,
+
+    // Interrupt
+    output wire        irq_o,
+
+    // I2C tri-state pads
+    inout  wire        sda_io,
+    inout  wire        scl_io
+);
+
+    wire scl_pad_i;
+    wire scl_pad_o;
+    wire scl_padoen;
+    wire sda_pad_i;
+    wire sda_pad_o;
+    wire sda_padoen;
+
+    // Tri-state buffers (open-drain)
+    assign scl_io    = scl_padoen ? 1'bz : scl_pad_o;
+    assign scl_pad_i = scl_io;
+
+    assign sda_io    = sda_padoen ? 1'bz : sda_pad_o;
+    assign sda_pad_i = sda_io;
+
+    i2c_master_avalon #(
+        .DEFAULT_PRESCALE (DEFAULT_PRESCALE)
+    ) u_avalon (
+        .clk            (clk),
+        .reset_n        (reset_n),
+
+        .avs_address    (avs_address),
+        .avs_read       (avs_read),
+        .avs_readdata   (avs_readdata),
+        .avs_write      (avs_write),
+        .avs_writedata  (avs_writedata),
+        .avs_byteenable (avs_byteenable),
+        .avs_waitrequest(avs_waitrequest),
+
+        .irq_o          (irq_o),
+
+        .scl_pad_i      (scl_pad_i),
+        .scl_pad_o      (scl_pad_o),
+        .scl_padoen_o   (scl_padoen),
+        .sda_pad_i      (sda_pad_i),
+        .sda_pad_o      (sda_pad_o),
+        .sda_padoen_o   (sda_padoen)
+    );
+
+endmodule

--- a/tb/avalon_mm_master_bfm.sv
+++ b/tb/avalon_mm_master_bfm.sv
@@ -1,0 +1,68 @@
+`timescale 1ns / 1ps
+// ---------------------------------------------------------------------------
+// Avalon-MM Master BFM — behavioural bus-functional model for simulation
+// ---------------------------------------------------------------------------
+module avalon_mm_master_bfm #(
+    parameter DATA_WIDTH = 32,
+    parameter ADDR_WIDTH = 3
+)(
+    input  wire                    clk,
+    input  wire                    reset_n,
+
+    output reg  [ADDR_WIDTH-1:0]   m_avs_address,
+    output reg                     m_avs_read,
+    input  wire [DATA_WIDTH-1:0]   m_avs_readdata,
+    output reg                     m_avs_write,
+    output reg  [DATA_WIDTH-1:0]   m_avs_writedata,
+    output reg  [DATA_WIDTH/8-1:0] m_avs_byteenable,
+    input  wire                    m_avs_waitrequest
+);
+
+    initial begin
+        m_avs_address    = 0;
+        m_avs_read       = 0;
+        m_avs_write      = 0;
+        m_avs_writedata  = 0;
+        m_avs_byteenable = 0;
+    end
+
+    // ---------------------------------------------------------------
+    // Avalon write (word address)
+    // ---------------------------------------------------------------
+    task avl_write(
+        input [ADDR_WIDTH-1:0] addr,
+        input [DATA_WIDTH-1:0] data
+    );
+        begin
+            @(posedge clk);
+            m_avs_address    <= addr;
+            m_avs_writedata  <= data;
+            m_avs_byteenable <= {(DATA_WIDTH/8){1'b1}};
+            m_avs_write      <= 1'b1;
+
+            @(posedge clk);
+            while (m_avs_waitrequest) @(posedge clk);
+            m_avs_write <= 1'b0;
+        end
+    endtask
+
+    // ---------------------------------------------------------------
+    // Avalon read (word address)
+    // ---------------------------------------------------------------
+    task avl_read(
+        input  [ADDR_WIDTH-1:0] addr,
+        output [DATA_WIDTH-1:0] data
+    );
+        begin
+            @(posedge clk);
+            m_avs_address <= addr;
+            m_avs_read    <= 1'b1;
+
+            @(posedge clk);
+            while (m_avs_waitrequest) @(posedge clk);
+            data = m_avs_readdata;
+            m_avs_read <= 1'b0;
+        end
+    endtask
+
+endmodule

--- a/tb/i2c_master_c4_tb.sv
+++ b/tb/i2c_master_c4_tb.sv
@@ -1,0 +1,422 @@
+`timescale 1ns / 1ps
+// ---------------------------------------------------------------------------
+// I2C Master Controller — Cyclone IV testbench (Avalon-MM)
+//
+// Same test scenarios as AXI version, but using Avalon-MM BFM
+// and i2c_master_top_c4 DUT.
+// ---------------------------------------------------------------------------
+module i2c_master_c4_tb;
+
+    // ---------------------------------------------------------------
+    // Parameters
+    // ---------------------------------------------------------------
+    localparam CLK_PERIOD    = 20;           // 50 MHz (typical Cyclone IV)
+    localparam PRESCALE_VAL  = 16'd4;        // Fast for simulation
+    localparam ADDR_WIDTH    = 3;
+    localparam DATA_WIDTH    = 32;
+    localparam [6:0] SLAVE_ADDR = 7'h50;
+
+    // Register word-addresses (byte addr / 4)
+    localparam [ADDR_WIDTH-1:0]
+        REG_CTRL     = 3'd0,
+        REG_STATUS   = 3'd1,
+        REG_CMD      = 3'd2,
+        REG_TX_DATA  = 3'd3,
+        REG_RX_DATA  = 3'd4,
+        REG_PRESCALE = 3'd5,
+        REG_ISR      = 3'd6;
+
+    // CMD bits
+    localparam CMD_STA  = 32'h01;
+    localparam CMD_STO  = 32'h02;
+    localparam CMD_RD   = 32'h04;
+    localparam CMD_WR   = 32'h08;
+    localparam CMD_NACK = 32'h10;
+
+    // ---------------------------------------------------------------
+    // Clock and reset
+    // ---------------------------------------------------------------
+    reg clk;
+    reg reset_n;
+
+    initial clk = 0;
+    always #(CLK_PERIOD/2) clk = ~clk;
+
+    // ---------------------------------------------------------------
+    // I2C bus with pull-ups
+    // ---------------------------------------------------------------
+    wire sda, scl;
+    pullup (sda);
+    pullup (scl);
+
+    // ---------------------------------------------------------------
+    // Avalon BFM wires
+    // ---------------------------------------------------------------
+    wire [ADDR_WIDTH-1:0]  avs_address;
+    wire                   avs_read;
+    wire [DATA_WIDTH-1:0]  avs_readdata;
+    wire                   avs_write;
+    wire [DATA_WIDTH-1:0]  avs_writedata;
+    wire [DATA_WIDTH/8-1:0] avs_byteenable;
+    wire                   avs_waitrequest;
+    wire                   irq;
+
+    // ---------------------------------------------------------------
+    // DUT — Cyclone IV top
+    // ---------------------------------------------------------------
+    i2c_master_top_c4 #(
+        .DEFAULT_PRESCALE (PRESCALE_VAL)
+    ) dut (
+        .clk             (clk),
+        .reset_n         (reset_n),
+
+        .avs_address     (avs_address),
+        .avs_read        (avs_read),
+        .avs_readdata    (avs_readdata),
+        .avs_write       (avs_write),
+        .avs_writedata   (avs_writedata),
+        .avs_byteenable  (avs_byteenable),
+        .avs_waitrequest (avs_waitrequest),
+
+        .irq_o           (irq),
+        .sda_io          (sda),
+        .scl_io          (scl)
+    );
+
+    // ---------------------------------------------------------------
+    // I2C Slave model
+    // ---------------------------------------------------------------
+    i2c_slave_model #(
+        .I2C_ADDR (SLAVE_ADDR)
+    ) slave (
+        .sda_io (sda),
+        .scl_io (scl)
+    );
+
+    // ---------------------------------------------------------------
+    // Avalon-MM Master BFM
+    // ---------------------------------------------------------------
+    avalon_mm_master_bfm #(
+        .DATA_WIDTH (DATA_WIDTH),
+        .ADDR_WIDTH (ADDR_WIDTH)
+    ) bfm (
+        .clk              (clk),
+        .reset_n          (reset_n),
+
+        .m_avs_address    (avs_address),
+        .m_avs_read       (avs_read),
+        .m_avs_readdata   (avs_readdata),
+        .m_avs_write      (avs_write),
+        .m_avs_writedata  (avs_writedata),
+        .m_avs_byteenable (avs_byteenable),
+        .m_avs_waitrequest(avs_waitrequest)
+    );
+
+    // ---------------------------------------------------------------
+    // Helper tasks
+    // ---------------------------------------------------------------
+    reg [DATA_WIDTH-1:0] rd_data;
+    integer test_pass, test_fail;
+
+    task wait_tip_clear;
+        integer timeout;
+        begin
+            timeout = 0;
+            rd_data = 32'h1;
+            while (rd_data[0] && timeout < 5000) begin
+                bfm.avl_read(REG_STATUS, rd_data);
+                timeout = timeout + 1;
+            end
+            if (timeout >= 5000)
+                $error("TIMEOUT: TIP did not clear");
+        end
+    endtask
+
+    task i2c_write_byte(
+        input [6:0] slave_addr,
+        input [7:0] reg_addr,
+        input [7:0] data
+    );
+        begin : wr_body
+            $display("[%0t] I2C WRITE: slave=0x%02h reg=0x%02h data=0x%02h",
+                     $time, slave_addr, reg_addr, data);
+
+            bfm.avl_write(REG_TX_DATA, {24'd0, slave_addr, 1'b0});
+            bfm.avl_write(REG_CMD, CMD_STA | CMD_WR);
+            wait_tip_clear();
+
+            bfm.avl_read(REG_STATUS, rd_data);
+            if (rd_data[1]) begin
+                $error("  NACK on slave address");
+                test_fail = test_fail + 1;
+                disable wr_body;
+            end
+
+            bfm.avl_write(REG_TX_DATA, {24'd0, reg_addr});
+            bfm.avl_write(REG_CMD, CMD_WR);
+            wait_tip_clear();
+
+            bfm.avl_write(REG_TX_DATA, {24'd0, data});
+            bfm.avl_write(REG_CMD, CMD_WR | CMD_STO);
+            wait_tip_clear();
+
+            $display("[%0t] I2C WRITE complete", $time);
+        end
+    endtask
+
+    task i2c_read_byte(
+        input  [6:0] slave_addr,
+        input  [7:0] reg_addr,
+        output [7:0] data
+    );
+        begin : rd_body
+            data = 8'hFF;
+            $display("[%0t] I2C READ: slave=0x%02h reg=0x%02h",
+                     $time, slave_addr, reg_addr);
+
+            bfm.avl_write(REG_TX_DATA, {24'd0, slave_addr, 1'b0});
+            bfm.avl_write(REG_CMD, CMD_STA | CMD_WR);
+            wait_tip_clear();
+
+            bfm.avl_read(REG_STATUS, rd_data);
+            if (rd_data[1]) begin
+                $error("  NACK on slave address (write phase)");
+                test_fail = test_fail + 1;
+                disable rd_body;
+            end
+
+            bfm.avl_write(REG_TX_DATA, {24'd0, reg_addr});
+            bfm.avl_write(REG_CMD, CMD_WR);
+            wait_tip_clear();
+
+            bfm.avl_write(REG_TX_DATA, {24'd0, slave_addr, 1'b1});
+            bfm.avl_write(REG_CMD, CMD_STA | CMD_WR);
+            wait_tip_clear();
+
+            bfm.avl_read(REG_STATUS, rd_data);
+            if (rd_data[1]) begin
+                $error("  NACK on slave address (read phase)");
+                test_fail = test_fail + 1;
+                disable rd_body;
+            end
+
+            bfm.avl_write(REG_CMD, CMD_RD | CMD_NACK | CMD_STO);
+            wait_tip_clear();
+
+            bfm.avl_read(REG_RX_DATA, rd_data);
+            data = rd_data[7:0];
+
+            $display("[%0t] I2C READ complete: data=0x%02h", $time, data);
+        end
+    endtask
+
+    // ---------------------------------------------------------------
+    // Test scenarios
+    // ---------------------------------------------------------------
+    reg [7:0] read_val;
+
+    initial begin
+        $dumpfile("i2c_master_c4_tb.vcd");
+        $dumpvars(0, i2c_master_c4_tb);
+
+        test_pass = 0;
+        test_fail = 0;
+
+        // Reset
+        reset_n = 0;
+        repeat (20) @(posedge clk);
+        reset_n = 1;
+        repeat (10) @(posedge clk);
+
+        // -------------------------------------------------------
+        // Test 0: Prescaler read-back
+        // -------------------------------------------------------
+        $display("\n=== TEST 0: Register read-back ===");
+        bfm.avl_read(REG_PRESCALE, rd_data);
+        if (rd_data[15:0] !== PRESCALE_VAL) begin
+            $error("  PRESCALE mismatch: got 0x%04h, expected 0x%04h",
+                   rd_data[15:0], PRESCALE_VAL);
+            test_fail = test_fail + 1;
+        end else begin
+            $display("  PRESCALE read-back OK: 0x%04h", rd_data[15:0]);
+            test_pass = test_pass + 1;
+        end
+
+        // Enable core
+        bfm.avl_write(REG_CTRL, 32'h03);
+        repeat (5) @(posedge clk);
+
+        // -------------------------------------------------------
+        // Test 1: Single byte write + read-back
+        // -------------------------------------------------------
+        $display("\n=== TEST 1: Single byte write + read-back ===");
+        i2c_write_byte(SLAVE_ADDR, 8'h10, 8'hA5);
+        repeat (100) @(posedge clk);
+
+        i2c_read_byte(SLAVE_ADDR, 8'h10, read_val);
+        if (read_val === 8'hA5) begin
+            $display("  PASS: read 0x%02h == expected 0xA5", read_val);
+            test_pass = test_pass + 1;
+        end else begin
+            $error("  FAIL: read 0x%02h != expected 0xA5", read_val);
+            test_fail = test_fail + 1;
+        end
+
+        // -------------------------------------------------------
+        // Test 2: Multi-byte write + read
+        // -------------------------------------------------------
+        $display("\n=== TEST 2: Multi-byte write + read-back ===");
+        i2c_write_byte(SLAVE_ADDR, 8'h20, 8'hDE);
+        repeat (100) @(posedge clk);
+        i2c_write_byte(SLAVE_ADDR, 8'h21, 8'hAD);
+        repeat (100) @(posedge clk);
+
+        i2c_read_byte(SLAVE_ADDR, 8'h20, read_val);
+        if (read_val === 8'hDE) begin
+            $display("  PASS: addr 0x20 = 0x%02h", read_val);
+            test_pass = test_pass + 1;
+        end else begin
+            $error("  FAIL: addr 0x20 = 0x%02h, expected 0xDE", read_val);
+            test_fail = test_fail + 1;
+        end
+
+        repeat (100) @(posedge clk);
+        i2c_read_byte(SLAVE_ADDR, 8'h21, read_val);
+        if (read_val === 8'hAD) begin
+            $display("  PASS: addr 0x21 = 0x%02h", read_val);
+            test_pass = test_pass + 1;
+        end else begin
+            $error("  FAIL: addr 0x21 = 0x%02h, expected 0xAD", read_val);
+            test_fail = test_fail + 1;
+        end
+
+        // -------------------------------------------------------
+        // Test 3: NACK on wrong address
+        // -------------------------------------------------------
+        $display("\n=== TEST 3: NACK on wrong slave address ===");
+        bfm.avl_write(REG_TX_DATA, {24'd0, 7'h3F, 1'b0});
+        bfm.avl_write(REG_CMD, CMD_STA | CMD_WR);
+        wait_tip_clear();
+        bfm.avl_read(REG_STATUS, rd_data);
+        if (rd_data[1]) begin
+            $display("  PASS: Got NACK for wrong address as expected");
+            test_pass = test_pass + 1;
+        end else begin
+            $error("  FAIL: Expected NACK but got ACK");
+            test_fail = test_fail + 1;
+        end
+        bfm.avl_write(REG_CMD, CMD_STO);
+        wait_tip_clear();
+
+        // -------------------------------------------------------
+        // Test 4: Interrupt flags
+        // -------------------------------------------------------
+        $display("\n=== TEST 4: Interrupt flags ===");
+        bfm.avl_write(REG_ISR, 32'h03);
+        repeat (5) @(posedge clk);
+        bfm.avl_read(REG_ISR, rd_data);
+        if (rd_data[1:0] === 2'b00) begin
+            $display("  PASS: ISR cleared");
+            test_pass = test_pass + 1;
+        end else begin
+            $error("  FAIL: ISR not cleared: 0x%02h", rd_data[1:0]);
+            test_fail = test_fail + 1;
+        end
+
+        i2c_write_byte(SLAVE_ADDR, 8'h30, 8'h42);
+        repeat (20) @(posedge clk);
+        bfm.avl_read(REG_ISR, rd_data);
+        if (rd_data[0]) begin
+            $display("  PASS: DONE interrupt set after write");
+            test_pass = test_pass + 1;
+        end else begin
+            $error("  FAIL: DONE interrupt not set");
+            test_fail = test_fail + 1;
+        end
+        bfm.avl_write(REG_ISR, 32'h01);
+
+        // -------------------------------------------------------
+        // Test 5: Back-to-back
+        // -------------------------------------------------------
+        $display("\n=== TEST 5: Back-to-back write + read ===");
+        i2c_write_byte(SLAVE_ADDR, 8'h40, 8'h55);
+        i2c_read_byte(SLAVE_ADDR, 8'h40, read_val);
+        if (read_val === 8'h55) begin
+            $display("  PASS: back-to-back OK: 0x%02h", read_val);
+            test_pass = test_pass + 1;
+        end else begin
+            $error("  FAIL: back-to-back: 0x%02h != 0x55", read_val);
+            test_fail = test_fail + 1;
+        end
+
+        // -------------------------------------------------------
+        // Test 6: Reset recovery
+        // -------------------------------------------------------
+        $display("\n=== TEST 6: Reset recovery ===");
+        reset_n = 0;
+        repeat (10) @(posedge clk);
+        reset_n = 1;
+        repeat (10) @(posedge clk);
+        bfm.avl_write(REG_CTRL, 32'h03);
+        repeat (5) @(posedge clk);
+
+        i2c_write_byte(SLAVE_ADDR, 8'h50, 8'hBB);
+        repeat (100) @(posedge clk);
+        i2c_read_byte(SLAVE_ADDR, 8'h50, read_val);
+        if (read_val === 8'hBB) begin
+            $display("  PASS: post-reset OK: 0x%02h", read_val);
+            test_pass = test_pass + 1;
+        end else begin
+            $error("  FAIL: post-reset: 0x%02h != 0xBB", read_val);
+            test_fail = test_fail + 1;
+        end
+
+        // -------------------------------------------------------
+        // Test 7: Prescaler change
+        // -------------------------------------------------------
+        $display("\n=== TEST 7: Prescaler change ===");
+        bfm.avl_write(REG_CTRL, 32'h00);
+        bfm.avl_write(REG_PRESCALE, 32'h0002);
+        bfm.avl_write(REG_CTRL, 32'h03);
+        repeat (5) @(posedge clk);
+
+        i2c_write_byte(SLAVE_ADDR, 8'h60, 8'hCC);
+        repeat (100) @(posedge clk);
+        i2c_read_byte(SLAVE_ADDR, 8'h60, read_val);
+        if (read_val === 8'hCC) begin
+            $display("  PASS: different prescaler OK: 0x%02h", read_val);
+            test_pass = test_pass + 1;
+        end else begin
+            $error("  FAIL: different prescaler: 0x%02h != 0xCC", read_val);
+            test_fail = test_fail + 1;
+        end
+
+        bfm.avl_write(REG_CTRL, 32'h00);
+        bfm.avl_write(REG_PRESCALE, {16'd0, PRESCALE_VAL});
+        bfm.avl_write(REG_CTRL, 32'h03);
+        repeat (5) @(posedge clk);
+
+        // -------------------------------------------------------
+        // Summary
+        // -------------------------------------------------------
+        repeat (200) @(posedge clk);
+        $display("\n============================================");
+        $display("  CYCLONE IV TB SUMMARY:  PASS=%0d  FAIL=%0d", test_pass, test_fail);
+        $display("============================================\n");
+        if (test_fail > 0)
+            $fatal(1, "Some tests FAILED");
+        else
+            $display("All tests PASSED");
+
+        $finish;
+    end
+
+    // ---------------------------------------------------------------
+    // Watchdog
+    // ---------------------------------------------------------------
+    initial begin
+        #100_000_000;
+        $fatal(1, "WATCHDOG: simulation timeout");
+    end
+
+endmodule


### PR DESCRIPTION
- Avalon-MM slave wrapper (i2c_master_avalon.v) with identical register map to AXI variant
- Top-level module (i2c_master_top_c4.v) with tri-state pads
- Avalon-MM master BFM for simulation
- Self-checking testbench (10 scenarios), all passing
- Integration guide for Cyclone IV / NIOS II / Platform Designer
- Updated Makefile with sim-c4/lint-c4 targets
- Updated README with dual-platform architecture

Made-with: Cursor